### PR TITLE
add discussion id to gitlab webhook payload

### DIFF
--- a/gitlab/payload.go
+++ b/gitlab/payload.go
@@ -730,6 +730,7 @@ type ObjectAttributes struct {
 	Target           Target     `json:"target"`
 	LastCommit       LastCommit `json:"last_commit"`
 	Assignee         Assignee   `json:"assignee"`
+	DiscussionID     string     `json:"discussion_id"` // thread id
 }
 
 // PipelineObjectAttributes contains pipeline specific GitLab object attributes information


### PR DESCRIPTION
## Description

Add discussion id (thread id) to gitlab webhook payload for comments

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
