### PR TITLE
add Type to distinguish gitlab DiffNote and DiscussionNote

### DIFF
--- a/gitlab/payload.go
+++ b/gitlab/payload.go
@@ -731,6 +731,7 @@ type ObjectAttributes struct {
 	LastCommit       LastCommit `json:"last_commit"`
 	Assignee         Assignee   `json:"assignee"`
 	DiscussionID     string     `json:"discussion_id"` // thread id
+	Type             string     `json:"type"`          // "DiffNote" or "DiscussionNote"
 }
 
 // PipelineObjectAttributes contains pipeline specific GitLab object attributes information


### PR DESCRIPTION
## Description

this field is in the DiffNote and DiscussionNote webhooks and allows us to distinguish a comment left on a code review vs a comment on the main Pull request

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
